### PR TITLE
Escape ']' and '\' in property values.

### DIFF
--- a/sgf.go
+++ b/sgf.go
@@ -3,6 +3,7 @@ package sgf
 import (
 	"bytes"
 	"io/ioutil"
+	"strings"
 )
 
 //
@@ -333,7 +334,9 @@ func appendGameTree(buffer *bytes.Buffer, gameTree *GameTree, format SgfFormat, 
 			// Property values
 			for _, value := range property.Values {
 				buffer.WriteRune('[')
-				buffer.WriteString(value)
+				escapedBackslash := strings.Replace(value, "\\", "\\\\", -1)
+				escaped := strings.Replace(escapedBackslash, "]", "\\]", -1)
+				buffer.WriteString(escaped)
 				buffer.WriteRune(']')
 			}
 		}

--- a/sgf_test.go
+++ b/sgf_test.go
@@ -50,6 +50,7 @@ func TestSgf(t *testing.T) {
 		{"(;FF[4]GM[1])", "", NoNewLinesSgfFormat},
 		{"(;FF[4];GM[1](;PB[Black]))", "", NoNewLinesSgfFormat},
 		{"(;FF[4]\n ;GM[1]\n    (;PB[Black]\n     ;PW[White]))", "", DefaultSgfFormat},
+		{"(;FF[4]GM[1]C[username [rank\\]: \\\\o])", "", DefaultSgfFormat},
 	}
 
 	for _, test := range okTests {


### PR DESCRIPTION
Hello. Thank you for sharing your SGF library.
Since the parser removes backslashes I believe the SGF writer should recreate them implicitly.